### PR TITLE
Add shared-memory TRT support and docker/launch updates

### DIFF
--- a/depth_anything_3_ros2/da3_inference.py
+++ b/depth_anything_3_ros2/da3_inference.py
@@ -223,6 +223,19 @@ class SharedMemoryInference:
         """Check if host TRT service is currently available."""
         return self._check_service()
 
+    def get_gpu_memory_usage(self) -> Optional[Dict[str, float]]:
+        """
+        Get GPU memory usage (not available for shared memory inference).
+
+        Returns:
+            None - GPU memory is managed by host TRT service
+        """
+        return None
+
+    def clear_cache(self) -> None:
+        """Clear cache (no-op for shared memory inference)."""
+        pass
+
 
 class DA3InferenceWrapper:
     """

--- a/depth_anything_3_ros2/depth_anything_3_node.py
+++ b/depth_anything_3_ros2/depth_anything_3_node.py
@@ -16,7 +16,7 @@ from sensor_msgs.msg import Image, CameraInfo
 from std_msgs.msg import Header
 from cv_bridge import CvBridge, CvBridgeError
 
-from .da3_inference import DA3InferenceWrapper
+from .da3_inference import DA3InferenceWrapper, SharedMemoryInference
 from .utils import normalize_depth, colorize_depth, PerformanceMetrics
 
 
@@ -44,17 +44,29 @@ class DepthAnything3Node(Node):
         # Initialize performance metrics
         self.metrics = PerformanceMetrics(window_size=30)
 
-        # Initialize DA3 model
-        self.get_logger().info(
-            f"Initializing Depth Anything 3 with model: {self.model_name}"
-        )
+        # Initialize inference backend
         try:
-            self.model = DA3InferenceWrapper(
-                model_name=self.model_name, device=self.device, cache_dir=self.cache_dir
-            )
-            self.get_logger().info("Model loaded successfully")
+            if self.use_shared_memory:
+                self.get_logger().info(
+                    "Initializing SharedMemoryInference for host TRT communication"
+                )
+                self.model = SharedMemoryInference(timeout=1.0)
+                if self.model.is_service_available:
+                    self.get_logger().info("Host TRT service detected and ready")
+                else:
+                    self.get_logger().warn(
+                        "Host TRT service not detected - will retry on first inference"
+                    )
+            else:
+                self.get_logger().info(
+                    f"Initializing Depth Anything 3 with model: {self.model_name}"
+                )
+                self.model = DA3InferenceWrapper(
+                    model_name=self.model_name, device=self.device, cache_dir=self.cache_dir
+                )
+            self.get_logger().info("Inference backend initialized successfully")
         except Exception as e:
-            self.get_logger().error(f"Failed to load model: {e}")
+            self.get_logger().error(f"Failed to initialize inference backend: {e}")
             raise
 
         # Setup QoS profile for subscriptions
@@ -122,6 +134,9 @@ class DepthAnything3Node(Node):
         # Logging
         self.declare_parameter("log_inference_time", False)
 
+        # Jetson TRT mode (host-container split)
+        self.declare_parameter("use_shared_memory", False)
+
     def _load_parameters(self) -> None:
         """Load parameters from ROS2 parameter server."""
         # Model configuration
@@ -147,6 +162,9 @@ class DepthAnything3Node(Node):
 
         # Logging
         self.log_inference_time = self.get_parameter("log_inference_time").value
+
+        # Jetson TRT mode
+        self.use_shared_memory = self.get_parameter("use_shared_memory").value
 
     def camera_info_callback(self, msg: CameraInfo) -> None:
         """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./models:/root/.cache/huggingface:rw
       - ./examples:/examples:ro
       - ./config:/app/config:ro
-    command: bash
+    command: bash -c "source /opt/ros/humble/setup.bash && source /ros2_ws/install/setup.bash && exec bash"
 
   # GPU-enabled deployment (requires nvidia-docker)
   depth-anything-3-gpu:
@@ -57,7 +57,7 @@ services:
       - ./config:/app/config:ro
       - /dev:/dev:rw  # For camera access
     privileged: true  # Required for camera access
-    command: bash
+    command: bash -c "source /opt/ros/humble/setup.bash && source /ros2_ws/install/setup.bash && exec bash"
 
   # Jetson ARM64 deployment (for NVIDIA Jetson devices)
   # Requires JetPack 6.2+ (L4T R36.4.x) with TensorRT 10.3 on host
@@ -106,7 +106,7 @@ services:
       - /usr/lib/aarch64-linux-gnu/libnvinfer_plugin.so.10.3.0:/usr/lib/aarch64-linux-gnu/libnvinfer_plugin.so.10:ro
       - /usr/lib/aarch64-linux-gnu/libnvonnxparser.so.10.3.0:/usr/lib/aarch64-linux-gnu/libnvonnxparser.so.10:ro
     privileged: true
-    command: bash
+    command: bash -c "source /opt/ros/humble/install/setup.bash 2>/dev/null || source /opt/ros/humble/setup.bash && source /ros2_ws/install/setup.bash && exec bash"
 
   # Development environment with mounted source
   depth-anything-3-dev:

--- a/launch/depth_anything_3.launch.py
+++ b/launch/depth_anything_3.launch.py
@@ -111,6 +111,13 @@ def generate_launch_description():
             description='Log per-frame inference time and performance metrics'
         ),
 
+        # Jetson TRT mode (host-container split)
+        DeclareLaunchArgument(
+            'use_shared_memory',
+            default_value='false',
+            description='Use shared memory for host TRT service communication (Jetson only)'
+        ),
+
         # Node
         Node(
             package='depth_anything_3_ros2',
@@ -136,6 +143,7 @@ def generate_launch_description():
                 'queue_size': LaunchConfiguration('queue_size'),
                 'processing_threads': LaunchConfiguration('processing_threads'),
                 'log_inference_time': LaunchConfiguration('log_inference_time'),
+                'use_shared_memory': LaunchConfiguration('use_shared_memory'),
             }]
         ),
     ])


### PR DESCRIPTION
Add optional SharedMemoryInference support for Jetson host<->container TensorRT setups and update node, launch, and docker-compose accordingly.

- da3_inference.py: add SharedMemoryInference no-op helpers (get_gpu_memory_usage -> None, clear_cache) to reflect GPU managed by host TRT service.
- depth_anything_3_node.py: add use_shared_memory parameter, import SharedMemoryInference, initialize either SharedMemoryInference (with availability checks and logs) or DA3InferenceWrapper, and improve init logging/error message.
- launch/depth_anything_3.launch.py: expose a use_shared_memory launch argument and pass it to the node.
- docker-compose.yml: update container commands to source ROS/workspace setup scripts on startup (including a Jetson-friendly fallback) so interactive shells have the correct environment.

These changes enable an optional host TRT service integration for Jetson deployments while preserving existing local inference behavior.
