### PR TITLE
Added param 'keep_image_size' to resize depth image and keep original…

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -11,6 +11,7 @@ depth_anything_3:
     inference_height: 518                   # Height for inference
     inference_width: 518                    # Width for inference
     input_encoding: "bgr8"                  # Expected input encoding (bgr8/rgb8)
+    keep_image_size: false                  # Resize output to match input resolution
 
     # Output configuration
     normalize_depth: true                   # Normalize depth to [0, 1] range

--- a/depth_anything_3_ros2/depth_anything_3_node.py
+++ b/depth_anything_3_ros2/depth_anything_3_node.py
@@ -15,9 +15,10 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from sensor_msgs.msg import Image, CameraInfo
 from std_msgs.msg import Header
 from cv_bridge import CvBridge, CvBridgeError
+import cv2
 
 from .da3_inference import DA3InferenceWrapper, SharedMemoryInference, SharedMemoryInferenceFast
-from .utils import normalize_depth, colorize_depth, PerformanceMetrics
+from .utils import normalize_depth, colorize_depth, PerformanceMetrics, resize_image
 
 
 class DepthAnything3Node(Node):
@@ -137,6 +138,7 @@ class DepthAnything3Node(Node):
         self.declare_parameter("inference_height", 518)
         self.declare_parameter("inference_width", 518)
         self.declare_parameter("input_encoding", "bgr8")
+        self.declare_parameter("keep_image_size", False)
 
         # Output configuration
         self.declare_parameter("normalize_depth", True)
@@ -166,6 +168,7 @@ class DepthAnything3Node(Node):
         self.inference_height = self.get_parameter("inference_height").value
         self.inference_width = self.get_parameter("inference_width").value
         self.input_encoding = self.get_parameter("input_encoding").value
+        self.keep_image_size = self.get_parameter("keep_image_size").value
 
         # Output configuration
         self.normalize_depth_output = self.get_parameter("normalize_depth").value
@@ -232,6 +235,17 @@ class DepthAnything3Node(Node):
 
             # Extract depth map
             depth_map = result["depth"]
+
+            # Resize if requested
+            if self.keep_image_size:
+                original_size = (cv_image.shape[0], cv_image.shape[1])
+                depth_map = resize_image(
+                    depth_map, target_size=original_size, keep_aspect_ratio=False, interpolation=cv2.INTER_LINEAR
+                )
+                if "confidence" in result:
+                    result["confidence"] = resize_image(
+                        result["confidence"], target_size=original_size, keep_aspect_ratio=False, interpolation=cv2.INTER_NEAREST
+                    )
 
             # Normalize if requested
             if self.normalize_depth_output:

--- a/launch/depth_anything_3.launch.py
+++ b/launch/depth_anything_3.launch.py
@@ -68,6 +68,11 @@ def generate_launch_description():
             default_value='bgr8',
             description='Expected input image encoding (bgr8 or rgb8)'
         ),
+        DeclareLaunchArgument(
+            'keep_image_size',
+            default_value='false',
+            description='Resize output depth map to match input image resolution'
+        ),
 
         # Output configuration
         DeclareLaunchArgument(
@@ -136,6 +141,7 @@ def generate_launch_description():
                 'inference_height': LaunchConfiguration('inference_height'),
                 'inference_width': LaunchConfiguration('inference_width'),
                 'input_encoding': LaunchConfiguration('input_encoding'),
+                'keep_image_size': LaunchConfiguration('keep_image_size'),
                 'normalize_depth': LaunchConfiguration('normalize_depth'),
                 'publish_colored': LaunchConfiguration('publish_colored'),
                 'publish_confidence': LaunchConfiguration('publish_confidence'),


### PR DESCRIPTION
… RGB image size

## Description

Added param 'keep_image_size' to resize depth image (and depth_colored image and confidence) in case the user wants to keep original RGB image size. Default value is false, so it is a non-breaking change which adds functionality. 

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Testing

Tested echoing topics and looking at the "height" and "width" fields of each message as well as at the size of each image itself. 

**Test Configuration**:
- OS: Ubuntu 24.04
- ROS2 Version: Jazzy
- Device (CPU/GPU): GPU
- Camera (if applicable): RealSense D435i

## Checklist

- [X] My code follows the style guidelines of this project (PEP 8, no emojis)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have maintained camera-agnostic design principles
- [X] I have checked my code for potential security issues

## Camera-Agnostic Design

- [X] N/A - This PR does not involve camera integration

## Performance Impact

- [X] No performance impact

## Additional Notes

You already had the fuction in utils.py. Just not using it.
